### PR TITLE
 Update bomoko/mysql-cnf-parser requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "symfony/console": "^3.0",
     "ifsnop/mysqldump-php": "dev-master",
     "cweagans/composer-patches": "^1.6",
-    "bomoko/mysql-cnf-parser": "^0.0.2",
+    "bomoko/mysql-cnf-parser": "master",
     "fzaninotto/faker": "^1.7",
     "symfony/event-dispatcher": "~3.4|~4.0"
   },


### PR DESCRIPTION
- bomoko/mysql-cnf-parser master now has "nette/finder": "^2.5 || ^3.0@dev", allowing this to work on PHP 7.x.
- 0.0.2 required "nette/finder": "^3.0@dev" which required "php": ">=8.0 <8.1"
- the update hasn't been tagged yet so may want to adjust this once the tag is added.